### PR TITLE
Add Goroutines.Num gauge returning number of existing goroutines

### DIFF
--- a/runtime/goroutines.go
+++ b/runtime/goroutines.go
@@ -1,0 +1,13 @@
+package runtime
+
+import (
+	"runtime"
+
+	"github.com/codahale/metrics"
+)
+
+func init() {
+	metrics.Gauge("Goroutines.Num").SetFunc(func() int64 {
+		return int64(runtime.NumGoroutine())
+	})
+}

--- a/runtime/goroutines_test.go
+++ b/runtime/goroutines_test.go
@@ -1,0 +1,21 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/codahale/metrics"
+)
+
+func TestGoroutinesStats(t *testing.T) {
+	_, gauges := metrics.Snapshot()
+
+	expected := []string{
+		"Goroutines.Num",
+	}
+
+	for _, name := range expected {
+		if _, ok := gauges[name]; !ok {
+			t.Errorf("Missing gauge %q", name)
+		}
+	}
+}


### PR DESCRIPTION
This allows for debugging whether bugs are causing goroutines to hang around.

r? @codahale 