### PR TITLE
Windows Support

### DIFF
--- a/runtime/fds.go
+++ b/runtime/fds.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package runtime
 
 import (

--- a/runtime/fds_test.go
+++ b/runtime/fds_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package runtime
 
 import (

--- a/runtime/fds_windows.go
+++ b/runtime/fds_windows.go
@@ -1,0 +1,8 @@
+package runtime
+
+import (
+	"github.com/codahale/metrics"
+)
+
+func init() {
+}

--- a/runtime/fds_windows.go
+++ b/runtime/fds_windows.go
@@ -1,8 +1,4 @@
 package runtime
 
-import (
-	"github.com/codahale/metrics"
-)
-
 func init() {
 }


### PR DESCRIPTION
Metrics Fails on Windows due to some missing methods. 

This patch should properly address that 

(sorry, but I <3 to develop for Windows)