### PR TITLE
freebsd: convert rlimit.Cur to uint64

### DIFF
--- a/runtime/fds.go
+++ b/runtime/fds.go
@@ -14,7 +14,7 @@ func getFDLimit() (uint64, error) {
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlimit); err != nil {
 		return 0, err
 	}
-	return rlimit.Cur, nil
+	return uint64(rlimit.Cur), nil
 }
 
 func getFDUsage() (uint64, error) {


### PR DESCRIPTION
Hi,

the `rlimit.Cur` is a `int64` so I just hardcoded the conversion. Are you fine with this? Otherwise I can break out the function and add a `_freebsd.go` file etc but this seemed easier.

log from current master:
```
[cryptix@svahnry ~/go/src/github.com/codahale/metrics/runtime:master] uname -a
FreeBSD svahnry 10.1-RELEASE-p9 FreeBSD 10.1-RELEASE-p9 #0: Tue Apr  7 01:09:46 UTC 2015     root@amd64-builder.daemonology.net:/usr/obj/usr/src/sys/GENERIC  amd64
[cryptix@svahnry ~/go/src/github.com/codahale/metrics/runtime:master] go test 
# github.com/codahale/metrics/runtime
./fds.go:17: cannot use rlimit.Cur (type int64) as type uint64 in return argument
FAIL	github.com/codahale/metrics/runtime [build failed]
```
